### PR TITLE
fix difftest interupt and vstart

### DIFF
--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -102,7 +102,7 @@ void DifftestRef::get_regs(diff_context_t *ctx) {
     ctx->vr[i]._64[1] = vReg_Val1;
   }
   /***************************************************************************************************/
-  ctx->vstart     = vstate.vstart->read();
+  ctx->vstart     = 0;//vstate.vstart->read();
   ctx->vxsat      = vstate.vxsat->read();
   ctx->vxrm       = vstate.vxrm->read();
   ctx->vcsr       = state->csrmap[CSR_VCSR]->read();
@@ -150,7 +150,8 @@ void DifftestRef::set_regs(diff_context_t *ctx, bool on_demand) {
     state->satp->write(ctx->satp);
   }
   if (!on_demand || state->mip->read() != ctx->mip) {
-    state->mip->write(ctx->mip);
+    //copy mip may cause spike to trigger interrupt independently
+    //state->mip->write(ctx->mip);
   }
   if (!on_demand || state->mie->read() != ctx->mie) {
     state->mie->write(ctx->mie);


### PR DESCRIPTION
Synchronization is triggered after NEMU enters the interrupt, spike skips this run, and MIP remains, causing SPIKE to trigger additional interrupts after the synchronization.
The vstart is not 0 when Spike Vector triggers an exception, but NEMU now has a constant vstart of 0 after execution.