### PR TITLE
difftest: fix unexcepted non-trap when accessing 16-63 PMP CSRs

### DIFF
--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -24,6 +24,7 @@
 #define CONFIG_FLASH_BASE      0x40000000UL
 #define CONFIG_FLASH_SIZE      0x1000UL
 #define CONFIG_PMP_NUM         0
+#define CONFIG_PMP_MAX_NUM     0
 #elif defined(CPU_XIANGSHAN)
     #if defined(CONFIG_DIFF_RVV)
     #define CONFIG_DIFF_ISA_STRING "RV64IMAFDCV_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_svinval"
@@ -34,6 +35,7 @@
 #define CONFIG_FLASH_BASE      0x10000000UL
 #define CONFIG_FLASH_SIZE      0x100000UL
 #define CONFIG_PMP_NUM         16
+#define CONFIG_PMP_MAX_NUM     16
 #define CONFIG_PMP_GRAN        12
 #elif defined(CPU_ROCKET_CHIP)
 #define CONFIG_DIFF_ISA_STRING "rv64imafdczicsr_zifencei_zihpm_zicntr"
@@ -41,6 +43,7 @@
 #define CONFIG_FLASH_BASE      0x10000000UL
 #define CONFIG_FLASH_SIZE      0x10000UL
 #define CONFIG_PMP_NUM         0
+#define CONFIG_PMP_MAX_NUM     64
 #endif
 
 #endif

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -149,7 +149,11 @@ struct state_t
 
   mseccfg_csr_t_p mseccfg;
 
+#ifdef CONFIG_PMP_MAX_NUM
+  static const int max_pmp = CONFIG_PMP_MAX_NUM;
+#else
   static const int max_pmp = 64;
+#endif
   pmpaddr_csr_t_p pmpaddr[max_pmp];
 
   float_csr_t_p fflags;


### PR DESCRIPTION
Add a macro CONFIG_PMP_MAX_NUM to control the number of "implemented" PMP CSRs.

This is a implementation difference between XiangShan and SPIKE. 

* XiangShan only "implements" 16 PMP entries (CSRs), and it will trap when accessing 16\~63 PMP entries (CSRs), such as `pmpaddr16`. 
* SPIKE could be set to only have 16 PMP entries, but it "implements" all 64 of PMP entries (CSRs) and just set 16\~63 PMP entries read-only 0. It won't trap when accessing 16~63 PMP entries (CSRs), such as `pmpaddr16`. 

Both of them is accepted by RISC-V Spec. 

