### PR TITLE
config: rewrite isa string define to allow enable both RVV & RVH

### DIFF
--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -26,20 +26,32 @@
 #define CONFIG_FLASH_SIZE      0x1000UL
 #define CONFIG_PMP_NUM         0
 #define CONFIG_PMP_MAX_NUM     0
+
 #elif defined(CPU_XIANGSHAN)
-    #if defined(CONFIG_DIFF_RVH)
-    #define CONFIG_DIFF_ISA_STRING "RV64IMAFDCH_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_svinval"
-    #elif defined(CONFIG_DIFF_RVV)
-    #define CONFIG_DIFF_ISA_STRING "RV64IMAFDCV_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_svinval"
-    #else
-    #define CONFIG_DIFF_ISA_STRING "RV64IMAFDC_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_svinval"
-    #endif // CONFIG_DIFF_RVV
+#ifdef CONFIG_DIFF_RVH
+    #define RVH_ISA_STRING "H"
+#else
+    #define RVH_ISA_STRING ""
+#endif
+#ifdef CONFIG_DIFF_RVV
+    #define RVV_ISA_STRING "H"
+#else
+    #define RVV_ISA_STRING ""
+#endif
+
+#define CONFIG_DIFF_ISA_STRING \
+    "RV64IMAFDC" \
+    RVV_ISA_STRING \
+    RVH_ISA_STRING \
+    "_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_svinval"
+
 #define CONFIG_MEMORY_SIZE     (16 * 1024 * 1024 * 1024UL)
 #define CONFIG_FLASH_BASE      0x10000000UL
 #define CONFIG_FLASH_SIZE      0x100000UL
 #define CONFIG_PMP_NUM         16
 #define CONFIG_PMP_MAX_NUM     16
 #define CONFIG_PMP_GRAN        12
+
 #elif defined(CPU_ROCKET_CHIP)
 #define CONFIG_DIFF_ISA_STRING "rv64imafdczicsr_zifencei_zihpm_zicntr"
 #define CONFIG_MEMORY_SIZE     (2 * 1024 * 1024 * 1024UL)


### PR DESCRIPTION
Rewrite isa string define to allow enable RVV, RVH, or both.