### PR TITLE
config: enable RVH for XiangShan as default

### DIFF
--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -15,7 +15,7 @@
 
 #if defined(CPU_XIANGSHAN)
 #define CONFIG_DIFF_DEBUG_MODE
-// #define CONFIG_DIFF_RVH  // Default off
+#define CONFIG_DIFF_RVH
 // #define CONFIG_DIFF_RVV  // Default off
 #endif
 


### PR DESCRIPTION
Enable RVH difftest in spike as default, as XiangShan has merged H-ext implementation.