### PR TITLE
store trace: could close store trace

### DIFF
--- a/difftest/difftrace.h
+++ b/difftest/difftrace.h
@@ -102,6 +102,9 @@ private:
 #ifdef CONFIG_DIFF_AMO_STORE
       do_trace = true;
 #endif
+#ifdef CONFIG_DIFF_NO_TRACE
+      do_trace = false;
+#endif
       if (do_trace) {
         store_trace_t trace{paddr, data, len};
         store_trace.push(trace);


### PR DESCRIPTION
NEMU could not enable dut_store_commit and performance optimization both, so to avoid memory leak, i think should close spike memory trace