### PR TITLE
wfi: treat wfi as nop when difftest

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -274,9 +274,12 @@ void processor_t::step(size_t n)
           }
 
           // debug mode wfis must nop
+          // difftest wfis must nop too
+          #ifndef DIFFTEST
           if (unlikely(in_wfi && !state.debug_mode)) {
             throw wait_for_interrupt_t();
           }
+          #endif
 
           in_wfi = false;
           insn_fetch_t fetch = mmu->load_insn(pc);


### PR DESCRIPTION
This patch fixes OpenXiangShan/NEMU#353.

When difftesting, wfi should just be nop. Otherwise, wfi will stall without pc+1 and cause out of sync between dut and ref.