### PR TITLE
Sdtrig: add difftest for sdtrig CSR in spike, and turn off it because it's not fully supported.

### DIFF
--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -20,6 +20,7 @@
 #define CONFIG_DIFF_ZICOND
 #define CONFIG_DIFF_ZICNTR
 #define CONFIG_DIFF_ZIHPM
+#define CONFIG_DIFF_SDTRIG
 #endif
 
 #if defined(CPU_NUTSHELL)
@@ -56,6 +57,11 @@
 #else
     #define ZIHPM_ISA_STRING ""
 #endif
+#ifdef CONFIG_DIFF_SDTRIG
+    #define SDTRIG_ISA_STRING "_sdtrig"
+#else
+    #define SDTRIG_ISA_STRING ""
+#endif
 
 #define CONFIG_DIFF_ISA_STRING \
     "RV64IMAFDC" \
@@ -64,6 +70,7 @@
     ZICOND_ISA_STRING \
     ZICNTR_ISA_STRING \
     ZIHPM_ISA_STRING \
+    SDTRIG_ISA_STRING \
     "_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_svinval"
 
 #define CONFIG_MEMORY_SIZE     (16 * 1024 * 1024 * 1024UL)

--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -20,7 +20,7 @@
 #define CONFIG_DIFF_ZICOND
 #define CONFIG_DIFF_ZICNTR
 #define CONFIG_DIFF_ZIHPM
-#define CONFIG_DIFF_SDTRIG
+// #define CONFIG_DIFF_SDTRIG
 #endif
 
 #if defined(CPU_NUTSHELL)

--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -136,6 +136,12 @@ void DifftestRef::get_regs(diff_context_t *ctx) {
   ctx->vtype      = vstate.vtype->read();
   ctx->vlenb      = vstate.vlenb;
 #endif // CONFIG_DIFF_RVV
+
+#ifdef CONFIG_DIFF_SDTRIG
+  ctx->tselect = state->tselect->read();
+  ctx->tdata1  = state->csrmap[CSR_TDATA1]->read();
+  ctx->tinfo   = state->csrmap[CSR_TINFO]->read();
+#endif // CONFIG_DIFF_SDTRIG
 }
 
 void DifftestRef::set_regs(diff_context_t *ctx, bool on_demand) {
@@ -324,6 +330,18 @@ void DifftestRef::set_regs(diff_context_t *ctx, bool on_demand) {
     vstate.vlenb = ctx->vlenb;
   }
 #endif // CONFIG_DIFF_RVV
+
+#ifdef CONFIG_DIFF_SDTRIG
+  if (!on_demand || state->tselect->read() != ctx->tselect) {
+    state->tselect->write(ctx->tselect);
+  }
+  if (!on_demand || state->csrmap[CSR_TDATA1]->read() != ctx->tdata1) {
+    state->csrmap[CSR_TDATA1]->write(ctx->tdata1);
+  }
+  if (!on_demand || state->csrmap[CSR_TINFO]->read() != ctx->tinfo) {
+    state->csrmap[CSR_TINFO]->write(ctx->tinfo);
+  }
+#endif // CONFIG_DIFF_SDTRIG
 }
 
 void DifftestRef::memcpy_from_dut(reg_t dest, void* src, size_t n) {

--- a/difftest/difftest.h
+++ b/difftest/difftest.h
@@ -92,6 +92,13 @@ typedef struct {
   uint64_t fcsr;
 #endif // CONFIG_DIFF_FPU
 
+#ifdef CONFIG_DIFF_SDTRIG
+  uint64_t tselect;
+  uint64_t tdata1;
+  uint64_t tinfo;
+  uint64_t tcontrol;
+#endif // CONFIG_DIFF_SDTRIG
+
 #ifdef CONFIG_DIFF_DEBUG_MODE
   uint64_t debugMode;
   uint64_t dcsr;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -935,7 +935,7 @@ bool medeleg_csr_t::unlogged_write(const reg_t val) noexcept {
     | (1 << CAUSE_FETCH_ACCESS)
 #endif
     | (1 << CAUSE_ILLEGAL_INSTRUCTION)
-    | (1 << CAUSE_BREAKPOINT)
+    | (proc->extension_enabled(EXT_SDTRIG) ? 0 : (1 << CAUSE_BREAKPOINT))
     | (1 << CAUSE_MISALIGNED_LOAD)
 #if !defined(CPU_ROCKET_CHIP)
     | (1 << CAUSE_LOAD_ACCESS)


### PR DESCRIPTION
Add difftest support for sdtrig CSR in spike except tcontrol and turn off sdtrig because tcontrol is not supported by spike.