### PR TITLE
Sdtrig: add difftest for sdtrig CSR in spike, and turn off it because it's not fully supported.

### DIFF
--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -20,7 +20,7 @@
 #define CONFIG_DIFF_ZICOND
 #define CONFIG_DIFF_ZICNTR
 #define CONFIG_DIFF_ZIHPM
-#define CONFIG_DIFF_SDTRIG
+// #define CONFIG_DIFF_SDTRIG
 #endif
 
 #if defined(CPU_NUTSHELL)

--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -20,7 +20,7 @@
 #define CONFIG_DIFF_ZICOND
 #define CONFIG_DIFF_ZICNTR
 #define CONFIG_DIFF_ZIHPM
-// #define CONFIG_DIFF_SDTRIG
+#define CONFIG_DIFF_SDTRIG
 #endif
 
 #if defined(CPU_NUTSHELL)

--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -30,6 +30,7 @@
 #define CONFIG_FLASH_SIZE      0x1000UL
 #define CONFIG_PMP_NUM         0
 #define CONFIG_PMP_MAX_NUM     0
+#define CONFIG_TRIGGER_NUM     0
 
 #elif defined(CPU_XIANGSHAN)
 #ifdef CONFIG_DIFF_RVH
@@ -79,6 +80,7 @@
 #define CONFIG_PMP_NUM         16
 #define CONFIG_PMP_MAX_NUM     16
 #define CONFIG_PMP_GRAN        12
+#define CONFIG_TRIGGER_NUM     4
 
 #elif defined(CPU_ROCKET_CHIP)
 #define CONFIG_DIFF_ISA_STRING "rv64imafdczicsr_zifencei_zihpm_zicntr"
@@ -87,6 +89,7 @@
 #define CONFIG_FLASH_SIZE      0x10000UL
 #define CONFIG_PMP_NUM         0
 #define CONFIG_PMP_MAX_NUM     64
+#define CONFIG_TRIGGER_NUM     0
 #endif
 
 #endif

--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -141,6 +141,7 @@ void DifftestRef::get_regs(diff_context_t *ctx) {
   ctx->tselect = state->tselect->read();
   ctx->tdata1  = state->csrmap[CSR_TDATA1]->read();
   ctx->tinfo   = state->csrmap[CSR_TINFO]->read();
+  ctx->tcontrol = state->tcontrol->read();
 #endif // CONFIG_DIFF_SDTRIG
 }
 
@@ -340,6 +341,9 @@ void DifftestRef::set_regs(diff_context_t *ctx, bool on_demand) {
   }
   if (!on_demand || state->csrmap[CSR_TINFO]->read() != ctx->tinfo) {
     state->csrmap[CSR_TINFO]->write(ctx->tinfo);
+  }
+  if (!on_demand || state->tcontrol->read() != ctx->tcontrol) {
+    state->tcontrol->write(ctx->tcontrol);
   }
 #endif // CONFIG_DIFF_SDTRIG
 }

--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -136,6 +136,12 @@ void DifftestRef::get_regs(diff_context_t *ctx) {
   ctx->vtype      = vstate.vtype->read();
   ctx->vlenb      = vstate.vlenb;
 #endif // CONFIG_DIFF_RVV
+
+#ifdef CONFIG_DIFF_SDTRIG
+  ctx->tselect = state->tselect->read();
+  ctx->tdata1  = state->csrmap[CSR_TDATA1]->read();
+  ctx->tinfo   = state->csrmap[CSR_TINFO]->read();
+#endif // CONFIG_DIFF_SDTRIG
 }
 
 void DifftestRef::set_regs(diff_context_t *ctx, bool on_demand) {
@@ -324,6 +330,18 @@ void DifftestRef::set_regs(diff_context_t *ctx, bool on_demand) {
     vstate.vlenb = ctx->vlenb;
   }
 #endif // CONFIG_DIFF_RVV
+
+#ifdef CONFIG_DIFF_SDTRIG
+  if (!on_demand || state->tselect->read() != ctx->tselect) {
+    state->tselect->write(ctx->tselect);
+  }
+  if (!on_demand || state->csrmap[CSR_TDATA1]->read() != ctx->tdata1) {
+    state->csrmap[CSR_TDATA1]->write(ctx->tdata1);
+  }
+  if (!on_demand || state->csrmap[CSR_TINFO]->read() != ctx->tinfo) {
+    state->csrmap[CSR_TINFO]->write(ctx->tinfo);
+  }
+#endif // CONFIG_DIFF_SDTRIG
 }
 
 void DifftestRef::memcpy_from_dut(reg_t dest, void* src, size_t n) {

--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -458,7 +458,7 @@ const cfg_t *DifftestRef::create_cfg() {
   cfg->mem_layout = memory_layout;
   cfg->hartids = std::vector<size_t>{overrided_mhartid};
   cfg->real_time_clint = false;
-  cfg->trigger_count = 0;
+  cfg->trigger_count = CONFIG_TRIGGER_NUM;
   return cfg;
 }
 

--- a/difftest/difftest.h
+++ b/difftest/difftest.h
@@ -92,6 +92,13 @@ typedef struct {
   uint64_t fcsr;
 #endif // CONFIG_DIFF_FPU
 
+#ifdef CONFIG_DIFF_SDTRIG
+  uint64_t tselect;
+  uint64_t tdata1;
+  uint64_t tinfo;
+  uint64_t tcontrol;
+#endif // CONFIG_DIFF_SDTRIG
+
 #ifdef CONFIG_DIFF_DEBUG_MODE
   uint64_t debugMode;
   uint64_t dcsr;

--- a/riscv/insn_template.h
+++ b/riscv/insn_template.h
@@ -8,4 +8,5 @@
 #include "specialize.h"
 #include "tracer.h"
 #include "v_ext_macros.h"
+#include "debug_defines.h"
 #include <assert.h>

--- a/riscv/insns/mret.h
+++ b/riscv/insns/mret.h
@@ -15,4 +15,5 @@ if (ZICFILP_xLPE(prev_virt, prev_prv)) {
 }
 STATE.mstatus->write(s);
 if (STATE.mstatush) STATE.mstatush->write(s >> 32); // log mstatush change
+STATE.tcontrol->write((STATE.tcontrol->read() & CSR_TCONTROL_MPTE) ? (CSR_TCONTROL_MPTE | CSR_TCONTROL_MTE) : 0);
 p->set_privilege(prev_prv, prev_virt);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -11,6 +11,7 @@
 #include "disasm.h"
 #include "platform.h"
 #include "vector_unit.h"
+#include "debug_defines.h"
 #include <cinttypes>
 #include <cmath>
 #include <cstdlib>
@@ -422,11 +423,13 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     csrmap[CSR_TDATA2] = tdata2 = std::make_shared<tdata2_csr_t>(proc, CSR_TDATA2);
     csrmap[CSR_TDATA3] = std::make_shared<tdata3_csr_t>(proc, CSR_TDATA3);
     csrmap[CSR_TINFO] = std::make_shared<tinfo_csr_t>(proc, CSR_TINFO);
+    csrmap[CSR_TCONTROL] = tcontrol = std::make_shared<masked_csr_t>(proc, CSR_TCONTROL, CSR_TCONTROL_MPTE | CSR_TCONTROL_MTE, 0);
   } else {
     csrmap[CSR_TDATA1] = std::make_shared<const_dtrig_csr_t>(proc, CSR_TDATA1, 0);
     csrmap[CSR_TDATA2] = tdata2 = std::make_shared<const_dtrig_csr_t>(proc, CSR_TDATA2, 0);
     csrmap[CSR_TDATA3] = std::make_shared<const_dtrig_csr_t>(proc, CSR_TDATA3, 0);
     csrmap[CSR_TINFO] = std::make_shared<const_dtrig_csr_t>(proc, CSR_TINFO, 0);
+    csrmap[CSR_TCONTROL] = tcontrol = std::make_shared<const_dtrig_csr_t>(proc, CSR_TCONTROL, 0);
   }
   unsigned scontext_length = (xlen == 32 ? 16 : 32); // debug spec suggests 16-bit for RV32 and 32-bit for RV64
   csrmap[CSR_SCONTEXT] = scontext = std::make_shared<masked_dtrig_csr_t>(proc, CSR_SCONTEXT, (reg_t(1) << scontext_length) - 1, 0);
@@ -1005,6 +1008,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     state.elp = elp_t::NO_LP_EXPECTED;
     state.mstatus->write(s);
     if (state.mstatush) state.mstatush->write(s >> 32);  // log mstatush change
+    state.tcontrol->write((state.tcontrol->read() & CSR_TCONTROL_MTE) ? CSR_TCONTROL_MPTE : 0);
     set_privilege(PRV_M, false);
   }
 }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -146,6 +146,7 @@ struct state_t
   dcsr_csr_t_p dcsr;
   csr_t_p tselect;
   csr_t_p tdata2;
+  csr_t_p tcontrol;
   csr_t_p scontext;
   csr_t_p mcontext;
 

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -59,7 +59,8 @@ bool trigger_t::common_match(processor_t * const proc, bool use_prev_prv) const 
   auto state = proc->get_state();
   auto prv = use_prev_prv ? state->prev_prv : state->prv;
   auto v = use_prev_prv ? state->prev_v : state->v;
-  return mode_match(prv, v) && textra_match(proc);
+  auto m_enabled = get_action() != 0 || (state->tcontrol->read() & CSR_TCONTROL_MTE);
+  return (prv < PRV_M || m_enabled) && mode_match(prv, v) && textra_match(proc);
 }
 
 bool trigger_t::mode_match(reg_t prv, bool v) const noexcept

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -622,6 +622,9 @@ std::optional<match_result_t> module_t::detect_trap_match(const trap_t& t) noexc
 
 reg_t module_t::tinfo_read(unsigned UNUSED index) const noexcept
 {
+#if defined(DIFFTEST) && defined(CPU_XIANGSHAN)
+  return (1 << CSR_TDATA1_TYPE_MCONTROL) ;
+#else
   /* In spike, every trigger supports the same types. */
   return (1 << CSR_TDATA1_TYPE_MCONTROL) |
          (1 << CSR_TDATA1_TYPE_ICOUNT) |
@@ -629,6 +632,7 @@ reg_t module_t::tinfo_read(unsigned UNUSED index) const noexcept
          (1 << CSR_TDATA1_TYPE_ETRIGGER) |
          (1 << CSR_TDATA1_TYPE_MCONTROL6) |
          (1 << CSR_TDATA1_TYPE_DISABLED);
+#endif
 }
 
 };


### PR DESCRIPTION
Add difftest support for sdtrig CSR in spike except tcontrol and turn off sdtrig because tcontrol is not supported by spike.