### PR TITLE
config: add config for paddr_bits and mmu_capability

### DIFF
--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -31,6 +31,8 @@
 #define CONFIG_PMP_NUM         0
 #define CONFIG_PMP_MAX_NUM     0
 #define CONFIG_TRIGGER_NUM     0
+#define CONFIG_MAX_PADDR_BITS  32
+#define CONFIG_MMU_CAPABILITY  IMPL_MMU_SV39
 
 #elif defined(CPU_XIANGSHAN)
 #ifdef CONFIG_DIFF_RVH
@@ -81,6 +83,8 @@
 #define CONFIG_PMP_MAX_NUM     16
 #define CONFIG_PMP_GRAN        12
 #define CONFIG_TRIGGER_NUM     4
+#define CONFIG_MAX_PADDR_BITS  48
+#define CONFIG_MMU_CAPABILITY  IMPL_MMU_SV48
 
 #elif defined(CPU_ROCKET_CHIP)
 #define CONFIG_DIFF_ISA_STRING "rv64imafdczicsr_zifencei_zihpm_zicntr"
@@ -90,6 +94,8 @@
 #define CONFIG_PMP_NUM         0
 #define CONFIG_PMP_MAX_NUM     64
 #define CONFIG_TRIGGER_NUM     0
+#define CONFIG_MAX_PADDR_BITS  32
+#define CONFIG_MMU_CAPABILITY  IMPL_MMU_SV39
 #endif
 
 #endif

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -19,10 +19,8 @@
 #define PGSHIFT 12
 const reg_t PGSIZE = 1 << PGSHIFT;
 const reg_t PGMASK = ~(PGSIZE-1);
-#if defined(CPU_ROCKET_CHIP) || defined(CPU_NUTSHELL)
-#define MAX_PADDR_BITS 32
-#elif defined(CPU_XIANGSHAN)
-#define MAX_PADDR_BITS 36
+#ifdef CONFIG_MAX_PADDR_BITS
+#define MAX_PADDR_BITS CONFIG_MAX_PADDR_BITS
 #else
 #define MAX_PADDR_BITS 56 // imposed by Sv39 / Sv48
 #endif

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -70,8 +70,8 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
   if (isa->get_max_xlen() == 32)
     set_mmu_capability(IMPL_MMU_SV32);
   else if (isa->get_max_xlen() == 64)
-#if defined(CPU_ROCKET_CHIP) || defined(CPU_NUTSHELL) || defined(CPU_XIANGSHAN)
-    set_mmu_capability(IMPL_MMU_SV39);
+#ifdef CONFIG_MMU_CAPABILITY
+    set_mmu_capability(CONFIG_MMU_CAPABILITY);
 #else
     set_mmu_capability(IMPL_MMU_SV57);
 #endif


### PR DESCRIPTION
XiangShan and NEMU are adding Sv48 support, so spike-so should also enable Sv48 for difftest. This patch move if-else-defined to difftest-def.h to make it clearer.

It seems we need something like menuconfig to arrange our configs. Now our difftest-def.h is so complex.