### PR TITLE
feat(trap): *tval captures inst on II & VI in XiangShan

### DIFF
--- a/riscv/trap.h
+++ b/riscv/trap.h
@@ -48,7 +48,7 @@ class insn_trap_t : public trap_t
   bool has_gva() override { return gva; }
   bool has_tval() override { return true; }
   reg_t get_tval() override {
-#ifdef CPU_ROCKET_CHIP
+#if defined(CPU_ROCKET_CHIP) || defined(CPU_XIANGSHAN)
     return tval;
 #else
     return 0;


### PR DESCRIPTION
Currently, XiangShan and NEMU have support capturing the faulting instruction when illegal-instruction or virtual-instruction exception occurs. This patch allows the spike to do so when difftesting with XiangShan.