### PR TITLE
config(XIANGSHAN): add sscofpmf, zfa & zfhmin

### DIFF
--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -74,7 +74,10 @@
     ZICNTR_ISA_STRING \
     ZIHPM_ISA_STRING \
     SDTRIG_ISA_STRING \
-    "_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_svinval"
+    "_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx" \
+    "_zknd_zkne_zknh_zksed_zksh" \
+    "_zfa_zfhmin" \
+    "_svinval_sscofpmf"
 
 #define CONFIG_MEMORY_SIZE     (16 * 1024 * 1024 * 1024UL)
 #define CONFIG_FLASH_BASE      0x10000000UL


### PR DESCRIPTION
This PR is a part of aligning NEMU's defconfigs.

Currently, the following extensions, although supported by XiangShan and NEMU, are still unusable during difftest with NEMU:
* AIA
* Sstc
* SMSTATEEN