### PR TITLE
fix(csr): htinst/mtinst are always written 0 when trap in XiangShan

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -503,7 +503,11 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
 #endif
     state.nonvirtual_stval->write(t.get_tval());
     state.htval->write(t.get_tval2());
+#ifdef CPU_XIANGSHAN
+    state.htinst->write(0);
+#else
     state.htinst->write(t.get_tinst());
+#endif
 
     reg_t s = state.nonvirtual_sstatus->read();
     s = set_field(s, MSTATUS_SPIE, get_field(s, MSTATUS_SIE));
@@ -553,7 +557,11 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     state.mcause->write(supv_double_trap ? CAUSE_DOUBLE_TRAP : t.cause());
     state.mtval->write(t.get_tval());
     state.mtval2->write(supv_double_trap ? t.cause() : t.get_tval2());
+#ifdef CPU_XIANGSHAN
+    state.mtinst->write(0);
+#else
     state.mtinst->write(t.get_tinst());
+#endif
 
     s = set_field(s, MSTATUS_MPIE, get_field(s, MSTATUS_MIE));
     s = set_field(s, MSTATUS_MPP, state.prv);


### PR DESCRIPTION
Currently, XiangShan only support writing 0 to htinst & mtinst CSRs when trap occurs. To align with XiangShan, this patch wraps the update of htinst & mtinst CSRs in take_trap function.