### PR TITLE
feat(csr): modify the warp for CSR time

### DIFF
--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -46,7 +46,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     add_csr(CSR_CYCLE, std::make_shared<counter_proxy_csr_t>(proc, CSR_CYCLE, mcycle));
 #ifndef CPU_ROCKET_CHIP
     add_csr(CSR_TIME, time_proxy = std::make_shared<counter_proxy_csr_t>(proc, CSR_TIME, time));
-#endif 
+#endif
   }
   if (xlen == 32) {
     csr_t_p minstreth, mcycleh;
@@ -60,7 +60,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
       add_csr(CSR_CYCLEH, std::make_shared<counter_proxy_csr_t>(proc, CSR_CYCLEH, mcycleh));
 #ifndef CPU_ROCKET_CHIP
       add_csr(CSR_TIMEH, std::make_shared<counter_proxy_csr_t>(proc, CSR_TIMEH, timeh));
-#endif 
+#endif
     }
   } else {
     add_csr(CSR_MINSTRET, minstret);

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -44,9 +44,9 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   if (proc->extension_enabled_const(EXT_ZICNTR)) {
     add_csr(CSR_INSTRET, std::make_shared<counter_proxy_csr_t>(proc, CSR_INSTRET, minstret));
     add_csr(CSR_CYCLE, std::make_shared<counter_proxy_csr_t>(proc, CSR_CYCLE, mcycle));
-#ifndef DIFFTEST
+#ifndef CPU_ROCKET_CHIP
     add_csr(CSR_TIME, time_proxy = std::make_shared<counter_proxy_csr_t>(proc, CSR_TIME, time));
-#endif
+#endif 
   }
   if (xlen == 32) {
     csr_t_p minstreth, mcycleh;
@@ -58,9 +58,9 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
       auto timeh = std::make_shared<rv32_high_csr_t>(proc, CSR_TIMEH, time);
       add_csr(CSR_INSTRETH, std::make_shared<counter_proxy_csr_t>(proc, CSR_INSTRETH, minstreth));
       add_csr(CSR_CYCLEH, std::make_shared<counter_proxy_csr_t>(proc, CSR_CYCLEH, mcycleh));
-#ifndef DIFFTEST
+#ifndef CPU_ROCKET_CHIP
       add_csr(CSR_TIMEH, std::make_shared<counter_proxy_csr_t>(proc, CSR_TIMEH, timeh));
-#endif
+#endif 
     }
   } else {
     add_csr(CSR_MINSTRET, minstret);


### PR DESCRIPTION
The modification is based on the following facts:
* Both XiangShan and NEMU support Zicntr extension, which includes three CSRs: cycle, time, instret.
* Rocket-chip support Zicntr except CSR time. In other words, Rocket-chip supports cycle and instret but does not support time.
* Nutshell does not support Zicntr.