### PR TITLE
config: add config for misaligned memory access

### DIFF
--- a/difftest/difftest-def.h
+++ b/difftest/difftest-def.h
@@ -33,6 +33,7 @@
 #define CONFIG_TRIGGER_NUM     0
 #define CONFIG_MAX_PADDR_BITS  32
 #define CONFIG_MMU_CAPABILITY  IMPL_MMU_SV39
+#define CONFIG_MISALIGNED      false
 
 #elif defined(CPU_XIANGSHAN)
 #ifdef CONFIG_DIFF_RVH
@@ -88,6 +89,7 @@
 #define CONFIG_TRIGGER_NUM     4
 #define CONFIG_MAX_PADDR_BITS  48
 #define CONFIG_MMU_CAPABILITY  IMPL_MMU_SV48
+#define CONFIG_MISALIGNED      true
 
 #elif defined(CPU_ROCKET_CHIP)
 #define CONFIG_DIFF_ISA_STRING "rv64imafdczicsr_zifencei_zihpm_zicntr"
@@ -99,6 +101,7 @@
 #define CONFIG_TRIGGER_NUM     0
 #define CONFIG_MAX_PADDR_BITS  32
 #define CONFIG_MMU_CAPABILITY  IMPL_MMU_SV39
+#define CONFIG_MISALIGNED      false
 #endif
 
 #endif

--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -447,7 +447,7 @@ const cfg_t *DifftestRef::create_cfg() {
   cfg->bootargs = nullptr;
   cfg->isa = CONFIG_DIFF_ISA_STRING;
   cfg->priv = DEFAULT_PRIV;
-  cfg->misaligned = false;
+  cfg->misaligned = CONFIG_MISALIGNED;
     // const endianness_t default_endianness,
   cfg->endianness = endianness_little;
   cfg->pmpregions = CONFIG_PMP_NUM;


### PR DESCRIPTION
Currently,
* Nutshell Rocket-chip does not support misaligned memory access
* XiangShan supports misaligned memory access for normal load/store, but does not support vector misaligned memory access.

Spike only supports enabling or disabling misaligned access for all memory access uniformly. This patch enables misaligned memory access of Spike for XiangShan, though it remains limited and not fully aligned between XiangShan and Spike.