### PR TITLE
fix: segment fault when access CSR sscratch when V=1

### DIFF
--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -151,8 +151,8 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   add_hypervisor_csr(CSR_VSTVAL, vstval = std::make_shared<basic_csr_t>(proc, CSR_VSTVAL, 0));
   add_supervisor_csr(CSR_STVAL, stval = std::make_shared<virtualized_csr_t>(proc, nonvirtual_stval, vstval));
   nonvirtual_sscratch = std::make_shared<basic_csr_t>(proc, CSR_SSCRATCH, 0);
-  add_supervisor_csr(CSR_SSCRATCH, sscratch = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sscratch, vsscratch));
   add_hypervisor_csr(CSR_VSSCRATCH, vsscratch = std::make_shared<basic_csr_t>(proc, CSR_VSSCRATCH, 0));
+  add_supervisor_csr(CSR_SSCRATCH, sscratch = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sscratch, vsscratch));
   nonvirtual_stvec = std::make_shared<tvec_csr_t>(proc, CSR_STVEC);
   add_hypervisor_csr(CSR_VSTVEC, vstvec = std::make_shared<tvec_csr_t>(proc, CSR_VSTVEC));
   add_supervisor_csr(CSR_STVEC, stvec = std::make_shared<virtualized_csr_t>(proc, nonvirtual_stvec, vstvec));


### PR DESCRIPTION
When creating virtualized_csr_t for CSR sscratch, vsscratch has not been created yet. As a result, a NULL pointer is passed to virtualized_csr_t and Segment Fault occurs when accessing CSR sscratch when V=1.