### PR TITLE
revert(csr): htinst/mtinst should follow the origin spike behaviour

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -503,11 +503,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
 #endif
     state.nonvirtual_stval->write(t.get_tval());
     state.htval->write(t.get_tval2());
-#ifdef CPU_XIANGSHAN
-    state.htinst->write(0);
-#else
     state.htinst->write(t.get_tinst());
-#endif
 
     reg_t s = state.nonvirtual_sstatus->read();
     s = set_field(s, MSTATUS_SPIE, get_field(s, MSTATUS_SIE));
@@ -557,11 +553,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     state.mcause->write(supv_double_trap ? CAUSE_DOUBLE_TRAP : t.cause());
     state.mtval->write(t.get_tval());
     state.mtval2->write(supv_double_trap ? t.cause() : t.get_tval2());
-#ifdef CPU_XIANGSHAN
-    state.mtinst->write(0);
-#else
     state.mtinst->write(t.get_tinst());
-#endif
 
     s = set_field(s, MSTATUS_MPIE, get_field(s, MSTATUS_MIE));
     s = set_field(s, MSTATUS_MPP, state.prv);


### PR DESCRIPTION
This patch reverts OpenXiangShan/riscv-isa-sim#33. According to RISC-V priv spec, htinst/mtinst could be zero when traps into HS/M-mode, except the both following conditions are met:
* the fault is caused by an implicit memory access for VS-stage address translation
* a nonzero value (the faulting guest physical address) is written to mtval2 or htval

Actually, XiangShan would write a nonzero value in such trap, so mtinst could not be written 0.

Acctually, spike only implements this nonzero situation for htinst/mtinst, so no more warps are needed.