### PR TITLE
fix(mip): update mip.mtip when mtime > mtimecmp in CPU_XIANGSHAN 

### DIFF
--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -394,6 +394,11 @@ void DifftestRef::raise_intr(uint64_t no) {
   }
 }
 
+void DifftestRef::update_mip(void *non_reg_interrupt_pending) {
+  auto n = (DifftestNonRegInterruptPending *) non_reg_interrupt_pending;
+  state->mip->backdoor_write_with_mask(MIP_MTIP, n->platform_irp_mtip ? MIP_MTIP : 0);
+}
+
 void DifftestRef::display() {
     int i;
   for (i = 0; i < 32; i ++) {
@@ -598,6 +603,10 @@ void difftest_close() {
 
 void difftest_set_ramsize(size_t size) {
   overrided_mem_size = size;
+}
+
+void difftest_non_reg_interrupt_pending(void *non_reg_interrupt_pending) {
+  ref->update_mip(non_reg_interrupt_pending);
 }
 
 }

--- a/difftest/difftest.h
+++ b/difftest/difftest.h
@@ -118,6 +118,18 @@ public:
   uint64_t sc_failed = 0;
 };
 
+class DifftestNonRegInterruptPending {
+  public:
+    bool platform_irp_meip = false;
+    bool platform_irp_mtip = false;
+    bool platform_irp_msip = false;
+    bool platform_irp_seip = false;
+    bool platform_irp_stip = false;
+    bool platform_irp_vseip = false;
+    bool platform_irp_vstip = false;
+    bool lcofi_req = false;
+};
+
 class DifftestRef {
 public:
   DifftestRef();
@@ -131,6 +143,7 @@ public:
   int store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask);
   void raise_intr(uint64_t no);
   void display();
+  void update_mip(void *non_reg_interrupt_pending);
   void update_dynamic_config(void* config) {
 #ifdef RISCV_ENABLE_COMMITLOG
   p->enable_log_commits();


### PR DESCRIPTION
This PR is used to pass XiangShan's Nightly CI test. 

`mtime` and `mtimecmp` are mmio type registers. We can change the values ​​of `mtime` and `mtimecmp` by writing data to memory. When `mtime` > `mtimecmp` will set `mip.mtip`.

When Spike running without using a dtb, skip the fdt-based configuration steps. There is no Clint in Spike's device tree. 

In order to allow Xiangshan and Spike to diff `mip` register, I update the mip.mtip bit through the difftest framework.