### PR TITLE
fix(icount): place the read before the return of the caller.

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -645,9 +645,6 @@ std::optional<match_result_t> module_t::detect_memory_access_match(operation_t o
 
 std::optional<match_result_t> module_t::detect_icount_match() noexcept
 {
-  for (auto trigger: triggers)
-    trigger->stash_read_values();
-
   state_t * const state = proc->get_state();
   if (state->debug_mode)
     return std::nullopt;
@@ -661,6 +658,10 @@ std::optional<match_result_t> module_t::detect_icount_match() noexcept
   if (ret == std::nullopt || ret->action != MCONTROL_ACTION_DEBUG_MODE)
     for (auto trigger: triggers)
       trigger->detect_icount_decrement(proc);
+
+  for (auto trigger: triggers)
+    trigger->stash_read_values();
+
   return ret;
 }
 


### PR DESCRIPTION
The values of `count_read_value` and `pending_read_value` read by `stash_read_values` are not used in the middle function calls, including `detect_icount_fire`, `detect_icount_decrement`.

When spike runs as the DUT, both methods are acceptable.

When spike runs as the REF, I may need to read the value of `icount` after the current instruction executed, and before executing the next instruction.

In this case, the second method can achieve this because it calls `stash_read_values()` after `detect_icount_fire()` and `detect_icount_decrement()`, which may write the `count` and `pending` field in `icount`. And `tdata1_read()` for `icount` use the `count_read_value` and `pending_read_value`, rathen than `count` and `pending`.