### PR TITLE
fix(sc): mcontrol6 addr trigger still match and fire for failed sc.

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -296,6 +296,11 @@ public:
   template<typename T>
   bool store_conditional(reg_t addr, T val)
   {
+    xlate_flags_t xlate_flags = {};
+    auto access_info = generate_access_info(addr, STORE, xlate_flags);
+    reg_t transformed_addr = access_info.transformed_vaddr;
+    check_triggers(triggers::OPERATION_STORE, transformed_addr, access_info.effective_virt);
+
     bool have_reservation = check_load_reservation(addr, sizeof(T));
     if (have_reservation && sim->sc_failed) {
       sim->difftest_log("The REF is forced to have an SC failure according to the DUT.");


### PR DESCRIPTION
If the sc instruction's addr is misaligned, it will check the addr trigger within the function check_load_reservation(), and raise misalign fault or access fault if addr trigger does not match.

However, for a properly aligned but failed sc instruction, spike does not execute the store function at all and does not check the addr trigger.

This patch checks the addr trigger right at the start of the sc instruction even if the sc instruction fails.