### PR TITLE
fix(store): make cross-page access consistent with XiangShan behavior

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -331,6 +331,14 @@ void mmu_t::store_slow_path(reg_t original_addr, reg_t len, const uint8_t* bytes
       throw trap_store_access_fault(gva, transformed_addr, 0, 0);
 
     reg_t len_page0 = std::min(len, PGSIZE - transformed_addr % PGSIZE);
+    
+#if defined(DIFFTEST) && defined(CPU_XIANGSHAN)
+    if (len_page0 != len){
+      store_slow_path_intrapage(len_page0, bytes, access_info, false);
+      store_slow_path_intrapage(len - len_page0, bytes + len_page0, access_info.split_misaligned_access(len_page0), false);
+    }
+#endif // defined(DIFFTEST) && defined(CPU_XIANGSHAN)
+
     store_slow_path_intrapage(len_page0, bytes, access_info, actually_store);
     if (len_page0 != len)
       store_slow_path_intrapage(len - len_page0, bytes + len_page0, access_info.split_misaligned_access(len_page0), actually_store);


### PR DESCRIPTION
When spike processes a cross-page store, it will be split into two stores and the two stores are independent of each other.
This means that if the store on the lower page can be completed and the store on the upper page triggers a PF exception, the store on the lower page will still be written to memory, and a PF exception will be triggered using the store on the upper page.
For XiangShan, this store instruction can only be completed normally if both stores of the cross-page store can be completed normally.
This modification aligns Spike with XiangShan in the case of CPU = XiangShan.