### PR TITLE
feat: add two api to support cpy pmp regs and pmp cfg regs

### DIFF
--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -486,6 +486,28 @@ const std::vector<std::pair<reg_t, abstract_device_t*>> DifftestRef::create_devi
   };
 }
 
+void DifftestRef::pmp_cfg_cpy(reg_t *dut, bool direction) {
+  auto xlen = p->get_isa().get_max_xlen();
+  for (int i = 0; i < state->max_pmp; i += xlen / 8) {
+    reg_t addr = CSR_PMPCFG0 + i / 4;
+    if (direction == DIFFTEST_TO_REF) {
+      state->csrmap[addr]->write(dut[addr]);
+    } else {
+      dut[addr] = state->csrmap[addr]->read();
+    }
+  }
+}
+
+void DifftestRef::pmpcpy(reg_t* dut, bool direction) {
+  for (int i = 0; i < CONFIG_PMP_NUM; i++) {
+    if (direction == DIFFTEST_TO_REF) {
+      state->pmpaddr[i]->write(dut[i]);
+    }else{
+      dut[i] = state->pmpaddr[i]->read();
+    }
+  }
+}
+
 sim_t *DifftestRef::create_sim(const cfg_t *cfg) {
   sim_t *s = new sim_t(
     // const cfg_t *cfg,
@@ -544,7 +566,15 @@ void difftest_regcpy(diff_context_t* dut, bool direction, bool on_demand) {
 }
 
 void difftest_csrcpy(void *dut, bool direction) {
+}
 
+
+void difftest_pmpcpy(void *dut, bool direction) {
+  ref->pmpcpy((reg_t*)dut, direction);
+}
+
+void difftest_pmp_cfg_cpy(void *dut, bool direction) {
+  ref->pmp_cfg_cpy((reg_t*)dut, direction);
 }
 
 void difftest_uarchstatus_sync(void *dut) {

--- a/difftest/difftest.h
+++ b/difftest/difftest.h
@@ -136,6 +136,8 @@ public:
   ~DifftestRef();
   void step(uint64_t n);
   void skip_one(bool isRVC, bool wen, uint32_t wdest, uint64_t wdata);
+  void pmpcpy(reg_t *dut, bool direction);
+  void pmp_cfg_cpy(reg_t *dut, bool direction);
   void get_regs(diff_context_t *ctx);
   void set_regs(diff_context_t *ctx, bool on_demand);
   void memcpy_from_dut(reg_t dest, void* src, size_t n);


### PR DESCRIPTION
When we skip the difftest in the checkpoint restore phase, the pmp and pmp cfg registers will not be set to the correct values, this patch add two api to fix this problem
