### PR TITLE
feat: support force flush non-reg values to avoid situations where non-register states are not set correctly in difftest

### DIFF
--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -466,6 +466,7 @@ const cfg_t *DifftestRef::create_cfg() {
   cfg->hartids = std::vector<size_t>{overrided_mhartid};
   cfg->real_time_clint = false;
   cfg->trigger_count = CONFIG_TRIGGER_NUM;
+  cfg->force_override = true;
   return cfg;
 }
 

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -77,6 +77,7 @@ public:
   bool                    explicit_hartids;
   bool                    real_time_clint;
   reg_t                   trigger_count;
+  bool                    force_override;
 
   size_t nprocs() const { return hartids.size(); }
   size_t max_hartid() const { return hartids.back(); }

--- a/riscv/vector_unit.cc
+++ b/riscv/vector_unit.cc
@@ -30,6 +30,7 @@ void vectorUnit_t::vectorUnit_t::reset()
 reg_t vectorUnit_t::vectorUnit_t::set_vl(int rd, int rs1, reg_t reqVL, reg_t newType)
 {
   int new_vlmul = 0;
+  /* After adding force_override, this judgment will always be true */
   if (vtype->read() != newType || p->get_cfg().force_override) {
     vsew = 1 << (extract64(newType, 3, 3) + 3);
     new_vlmul = int8_t(extract64(newType, 0, 3) << 5) >> 5;

--- a/riscv/vector_unit.cc
+++ b/riscv/vector_unit.cc
@@ -30,7 +30,7 @@ void vectorUnit_t::vectorUnit_t::reset()
 reg_t vectorUnit_t::vectorUnit_t::set_vl(int rd, int rs1, reg_t reqVL, reg_t newType)
 {
   int new_vlmul = 0;
-  if (vtype->read() != newType) {
+  if (vtype->read() != newType || p->get_cfg().force_override) {
     vsew = 1 << (extract64(newType, 3, 3) + 3);
     new_vlmul = int8_t(extract64(newType, 0, 3) << 5) >> 5;
     vflmul = new_vlmul >= 0 ? 1 << new_vlmul : 1.0 / (1 << -new_vlmul);

--- a/riscv/vector_unit.cc
+++ b/riscv/vector_unit.cc
@@ -30,7 +30,7 @@ void vectorUnit_t::vectorUnit_t::reset()
 reg_t vectorUnit_t::vectorUnit_t::set_vl(int rd, int rs1, reg_t reqVL, reg_t newType)
 {
   int new_vlmul = 0;
-  /* After adding force_override, this judgment will always be true */
+  /* After adding force_override, this condition will always be true */
   if (vtype->read() != newType || p->get_cfg().force_override) {
     vsew = 1 << (extract64(newType, 3, 3) + 3);
     new_vlmul = int8_t(extract64(newType, 0, 3) << 5) >> 5;


### PR DESCRIPTION
* If we first set the value of vtype using a register copy and the following vset instruction has the same value as that register, then non-register states such as vlmax will not be updated, and these states may have different values ​​than the register.