### PR TITLE
fix(intr): fix the interrupt priority of LCOFI

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -326,14 +326,14 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
       enabled_interrupts = MIP_SSIP;
     else if (enabled_interrupts & MIP_STIP)
       enabled_interrupts = MIP_STIP;
-    else if (enabled_interrupts & MIP_LCOFIP)
-      enabled_interrupts = MIP_LCOFIP;
     else if (enabled_interrupts & MIP_VSEIP)
       enabled_interrupts = MIP_VSEIP;
     else if (enabled_interrupts & MIP_VSSIP)
       enabled_interrupts = MIP_VSSIP;
     else if (enabled_interrupts & MIP_VSTIP)
       enabled_interrupts = MIP_VSTIP;
+    else if (enabled_interrupts & MIP_LCOFIP)
+      enabled_interrupts = MIP_LCOFIP;
     else
       abort();
 


### PR DESCRIPTION
Multiple simultaneous interrupts destined for HS-mode are handled in the following decreasing priority order: SEI, SSI, STI, SGEI, VSEI, VSSI, VSTI, LCOFI.