### PR TITLE
fix(hvip): Fix WMASK of LCOFI bit(bit 13) in hvip

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1971,8 +1971,7 @@ reg_t hvip_csr_t::read() const noexcept {
 
 bool hvip_csr_t::unlogged_write(const reg_t val) noexcept {
   state->mip->write_with_mask(MIP_VSSIP, val); // hvip.VSSIP is an alias of mip.VSSIP
-  const reg_t lscof_int = proc->extension_enabled(EXT_SSCOFPMF) ? MIP_LCOFIP : 0;
-  return basic_csr_t::unlogged_write(val & (lscof_int | MIP_VSEIP | MIP_VSTIP));
+  return basic_csr_t::unlogged_write(val & (MIP_VSEIP | MIP_VSTIP));
 }
 
 ssp_csr_t::ssp_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init):


### PR DESCRIPTION
For implementations that support Smcdeleg/Ssccfg, Sscofpmf, Smaia/Ssaia, and the H extension, the LCOFI bit (bit 13) in each of hvip and hvien is implemented and writable. It means only when all of these extensions implemented, the LCOFI bit (bit 13) in each of hvip and hvien is writablt.