### PR TITLE
fix(difftest): include `difftest-def.h` in spike

### DIFF
--- a/difftest/Makefile
+++ b/difftest/Makefile
@@ -10,8 +10,8 @@ SPIKE_PATH     = $(abspath ..)
 SPIKE_TARGET   = $(BUILD_DIR)/spike
 SPIKE_MAKEFILE = $(BUILD_DIR)/Makefile
 
-SPIKE_CFLAGS    = -O3 -DDIFFTEST
-SPIKE_CXXFLAGS  = -O3 -DDIFFTEST -Wno-c99-designator
+SPIKE_CFLAGS    = -O3 -DDIFFTEST -include $(abspath .)/difftest-def.h
+SPIKE_CXXFLAGS  = -O3 -DDIFFTEST -include $(abspath .)/difftest-def.h -Wno-c99-designator
 SPIKE_LDFLAGS   =
 
 ifneq ($(CPU),)


### PR DESCRIPTION
Previously, we only include `diffteset-def.h` in difftest-related files, which causes various inconsistencies in class or struct definitions.

Take `processor.h` for an example. The structure or size of `struct state_t` is dependent on the macro definition of `CONFIG_PMP_MAX_NUM` in `diffteset-def.h`. Different `CONFIG_PMP_MAX_NUM` results in different `struct state_t`, and further results in different `class processor_t`.

Considering that we includes `processor.h` and uses `class processor_t` in both `difftest/difftest.cc` and `riscv/sim.cc`, where the first `difftest/difftest.cc` has `CONFIG_PMP_MAX_NUM` defined but the second `riscv/sim.cc` not. If a variable of `class processor_t` is defined in one file and is used in another one (by global variable, return value of function call, etc.), the data may corrupt.

Here are some `printf`s below for better explanation.

```
----------/nfs/home/tanghaojin/riscv-isa-sim/riscv/sim.cc----------
sizeof processor_t: 0x412d8
sizeof state_t: 0xee0
procs[0] addr: 0x769751a81010
procs[0]->state.fflags addr: 0x769751a81df8
procs[0]->VU addr: 0x769751ac21f8
----------/nfs/home/tanghaojin/riscv-isa-sim/difftest/difftest.cc----------
sizeof processor_t: 0x40fd8
sizeof state_t: 0xbe0
procs[0] addr: 0x769751a81010
procs[0]->state.fflags addr: 0x769751a81af8
procs[0]->VU addr: 0x769751ac1ef8
```

This is a temporary fixup and a better way is to use a "spike-way" (autoconf / automake / `./configure`) to manage difftest codes with spike.