### PR TITLE
fix(raise_intr): fix raise_intr to allow clearing values in mip.

### DIFF
--- a/difftest/difftest.cc
+++ b/difftest/difftest.cc
@@ -391,11 +391,14 @@ void DifftestRef::raise_intr(uint64_t no) {
     // 0x1e00: 9 (Supervisor), 10 (Virtual supervisor), 11 (Machine), 12 (Supervisor guest)
     bool from_outside = !(mip_bit & state->mip->read());
     bool external_set = (is_timer_interrupt || is_external_interrupt) && from_outside;
+    p->check_interrupt = true;
     if (external_set) {
       state->mip->backdoor_write_with_mask(mip_bit, mip_bit);
+      step(1);
+      state->mip->backdoor_write_with_mask(mip_bit, ~mip_bit);
+    } else {
+      step(1);
     }
-    p->check_interrupt = true;
-    step(1);
     p->check_interrupt = false;
   }
 }


### PR DESCRIPTION
For external and timer interrupts from outside, we choose to let the DUT inform the REF when there is a pending interrupt and trigger it.
For these types of interrupts, we set the corresponding bit in `mip` to 1 so Spike can trigger the interrupt itself. 

Moreover, we cannot modify these bits in `mip` using the `csrrw` instruction because the corresponding bit of `mip` is non-writable.

Therefore, after triggering the interrupt, we should also clear the corresponding bit in `mip`; otherwise, it will persist in `mip` indefinitely.