### PR TITLE
fix(Difftest):  not operate on terminal when it does

### DIFF
--- a/fesvr/term.cc
+++ b/fesvr/term.cc
@@ -30,7 +30,9 @@ class canonical_termios_t
   bool restore_tios;
 };
 
+#ifndef DIFFTEST
 static canonical_termios_t tios; // exit() will clean up for us
+#endif // !DIFFTEST
 
 int canonical_terminal_t::read()
 {


### PR DESCRIPTION
We found that when NEMU does a difftest with Spike, NEMU's debug mode will have no echo back.
**This is confusing.**
After some hard searching, we found that spike blocks ECHO and ICANON from the terminal.

---

**In fact, this is necessary when spike is running alone, but when spike is used as a ref, we should not allow spike to operate on terminal properties.**