### PR TITLE
ci: add a workflow for release

### DIFF
--- a/.github/workflows/build-difftest-so.yml
+++ b/.github/workflows/build-difftest-so.yml
@@ -5,59 +5,25 @@ on:
     branches: [difftest]
   pull_request:
     branches: [difftest]
+  workflow_call:
 
 jobs:
   build:
     name: Build spike-so for difftest
     strategy:
       matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         cpu: [xiangshan, nutshell, rocket_chip]
-        os: [ubuntu-22.04, ubuntu-24.04]
-        toolchain:
-          - { cc: gcc, cxx: g++ }
-          - { cc: clang, cxx: clang++ }
-    runs-on: ${{ matrix.os }}
-    continue-on-error: false
-    timeout-minutes: 30
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Dependencies
-        run: sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
-
-      - name: build spike-so
-        run: |
-          BUILD_CPU=${{ matrix.cpu }}
-          make -C difftest CPU=${BUILD_CPU^^} -j4 \
-            CC=${{ matrix.toolchain.cc }}         \
-            CXX=${{ matrix.toolchain.cxx }}
-
-      - name: archive spike-so artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: riscv64-${{ matrix.cpu }}-spike-so-${{ matrix.os }}-${{ matrix.toolchain.cc }}
-          path: difftest/build/riscv64-spike-so
-  # fack you why you do not support YAML anchor? 
-  build-on-docker:
-    name: Build spike-so for difftest on docker
-    strategy:
-      matrix:
-        cpu: [xiangshan, nutshell, rocket_chip]
-        os: [ubuntu-20.04]
         toolchain:
           - { cc: gcc, cxx: g++ }
           - { cc: clang, cxx: clang++ }
     runs-on: ubuntu-latest
-    container: ghcr.io/openxiangshan/${{ matrix.os }}:latest
+    container: ghcr.io/openxiangshan/xs-env:${{ matrix.os }}
     continue-on-error: false
     timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Install Dependencies
-        run: sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
 
       - name: build spike-so
         run: |
@@ -66,8 +32,14 @@ jobs:
             CC=${{ matrix.toolchain.cc }}         \
             CXX=${{ matrix.toolchain.cxx }}
 
+      - name: Prepare artifact
+        run: |
+          mkdir -p artifact
+          cp difftest/build/riscv64-spike-so artifact/spike-${{ matrix.cpu }}-ref.so
+
       - name: archive spike-so artifacts
         uses: actions/upload-artifact@v4
+        if: matrix.os == 'ubuntu-20.04' && matrix.toolchain.cc == 'gcc'
         with:
-          name: riscv64-${{ matrix.cpu }}-spike-so-${{ matrix.os }}-${{ matrix.toolchain.cc }}
-          path: difftest/build/riscv64-spike-so
+          name: spike-${{ matrix.cpu }}-ref.so
+          path: artifact/spike-${{ matrix.cpu }}-ref.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,152 @@
+name: Release
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # 12:00 UTC+8
+  workflow_dispatch:
+
+jobs:
+  check-and-release:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check_diff.outputs.should_release }}
+      new_tag: ${{ steps.generate_tag.outputs.new_tag }}
+      latest_tag: ${{ steps.get_latest_tag.outputs.latest_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest release tag
+        id: get_latest_tag
+        run: |
+          latest_tag=$(git tag --sort=-version:refname | head -n 1)
+          if [ -z "$latest_tag" ]; then
+            echo "No previous release found"
+            echo "latest_tag=" >> $GITHUB_OUTPUT
+          else
+            echo "Latest tag: $latest_tag"
+            echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for changes since last release
+        id: check_diff
+        run: |
+          latest_tag="${{ steps.get_latest_tag.outputs.latest_tag }}"
+          if [ -z "$latest_tag" ]; then
+            echo "No previous release, will create first release"
+            echo "should_release=true" >> $GITHUB_OUTPUT
+          else
+            diff_count=$(git rev-list ${latest_tag}..HEAD --count)
+            if [ "$diff_count" -eq "0" ]; then
+              echo "No changes since last release ($latest_tag)"
+              echo "should_release=false" >> $GITHUB_OUTPUT
+            else
+              echo "Found $diff_count commits since last release"
+              echo "should_release=true" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Generate CalVer tag
+        id: generate_tag
+        if: steps.check_diff.outputs.should_release == 'true'
+        run: |
+          # Get current date (UTC+8)
+          TZ='Asia/Shanghai' year=$(date +%Y)
+          TZ='Asia/Shanghai' month=$(date +%m)
+          
+          # Find all version in this year/month with 'v' prefix and 'r' suffix
+          prefix="v${year}.${month}.r"
+          existing_tags=$(git tag -l "${prefix}*" | sort -V)
+          
+          if [ -z "$existing_tags" ]; then
+            # No version in this year/month, start from 1
+            micro=1
+          else
+            # Micro + 1
+            last_tag=$(echo "$existing_tags" | tail -n 1)
+            last_micro=$(echo "$last_tag" | sed "s/${prefix}//")
+            micro=$((last_micro + 1))
+          fi
+          
+          new_tag="v${year}.${month}.r${micro}"
+          echo "New tag: $new_tag"
+          echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
+
+  build:
+    name: build artifacts
+    needs: check-and-release
+    if: needs.check-and-release.outputs.should_release == 'true'
+    uses: ./.github/workflows/build-difftest-so.yml
+
+  create-release:
+    needs: [check-and-release, build]
+    if: needs.check-and-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: spike-*-ref.so
+          path: release-artifacts
+
+      - name: Prepare release assets
+        run: |
+          new_tag="${{ needs.check-and-release.outputs.new_tag }}"
+          cd release-artifacts
+          for dir in spike-*; do
+            if [ -d "$dir" ]; then
+              cd "$dir"
+              for file in spike-*.so; do
+                # Extract parts: spike-{cpu}-ref.so
+                # Insert version after 'spike-': spike-{version}-{cpu}-ref.so
+                new_name=$(echo "$file" | sed "s/^spike-/spike-${new_tag}-/")
+                mv "$file" "$new_name"
+              done
+              cd ..
+            fi
+          done
+
+      - name: Generate release notes
+        run: |
+          new_tag="${{ needs.check-and-release.outputs.new_tag }}"
+          # Remove 'v' prefix for parsing
+          version_num="${new_tag#v}"
+          year=$(echo "$version_num" | cut -d'.' -f1)
+          month=$(echo "$version_num" | cut -d'.' -f2)
+          micro=$(echo "$version_num" | sed 's/.*r//')
+          month_name=$(date -d "${year}-${month}-01" +"%B")
+          release_date=$(TZ='Asia/Shanghai' date +"%B %-d, %Y")
+          
+          cat > RELEASE_NOTES.md << EOF
+          Release ${new_tag} is the ${micro}th release in ${month_name} ${year}, released on ${release_date}.
+          
+          ## Artifacts
+          The release includes pre-compiled SPIKE shared objects for different configurations:
+          - Compilation Platform: Ubuntu 20.04 (compatible with CentOS 7)
+          - CPU: xiangshan, nutshell, rocket_chip
+          
+          Each artifact is named as: \`spike-{version}-{cpu}-ref.so\`
+          EOF
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.check-and-release.outputs.new_tag }}
+          name: Release ${{ needs.check-and-release.outputs.new_tag }}
+          body_path: RELEASE_NOTES.md
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            release-artifacts/*/*.so
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This patch adds a GitHub Actions workflow to automate the release process.

In addition, only artifacts built on Ubuntu 20.04 with GCC are now prepared for release.